### PR TITLE
Fix import package file path

### DIFF
--- a/qlang.v2/module2.go
+++ b/qlang.v2/module2.go
@@ -41,7 +41,7 @@ func findEntry(file string, libs []string) (string, error) {
 			continue
 		}
 		path := dir + "/" + file
-		if _, err := os.Stat(file); err == nil {
+		if _, err := os.Stat(path); err == nil {
 			return path, nil
 		}
 	}


### PR DESCRIPTION
fix bug: using plain(relative) file path, code at [qlang.v2/module2.go:44](https://github.com/qiniu/qlang/blob/develop/qlang.v2/module2.go#L44)