### PR TITLE
qexport support goapi version check, add +build verion export

### DIFF
--- a/app/qexport/api.go
+++ b/app/qexport/api.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func apipath(base string) string {
+	return filepath.Join(os.Getenv("GOROOT"), "api", base)
+}
+
+var sym = regexp.MustCompile(`^pkg (\S+)\s?(.*)?, (?:(var|func|type|const)) ([A-Z]\w*)`)
+
+type GoApi struct {
+	Keys map[string]bool
+	Ver  string
+}
+
+func LoadApi(ver string) (*GoApi, error) {
+	f, err := os.Open(apipath(ver + ".txt"))
+	if err != nil {
+		return nil, err
+	}
+	sc := bufio.NewScanner(f)
+	keys := make(map[string]bool)
+	for sc.Scan() {
+		l := sc.Text()
+		has := func(v string) bool { return strings.Contains(l, v) }
+		if has("interface, ") || has(", method (") {
+			continue
+		}
+		if m := sym.FindStringSubmatch(l); m != nil {
+			// 1 pkgname
+			// 2 os-arch-cgo
+			// 3 var|func|type|const
+			// 4 name
+			key := m[1] + "." + m[4]
+			keys[key] = true
+		}
+	}
+	return &GoApi{Ver: ver, Keys: keys}, nil
+}
+
+type ApiCheck struct {
+	Base map[string]bool
+	Apis []*GoApi
+}
+
+func NewApiCheck() *ApiCheck {
+	ac := &ApiCheck{}
+	ac.Base = make(map[string]bool)
+	return ac
+}
+
+func (ac *ApiCheck) LoadBase(vers ...string) error {
+	for _, ver := range vers {
+		api, err := LoadApi(ver)
+		if err != nil {
+			return err
+		}
+		for k, v := range api.Keys {
+			ac.Base[k] = v
+		}
+	}
+	return nil
+}
+
+func (ac *ApiCheck) LoadApi(vers ...string) error {
+	for _, ver := range vers {
+		api, err := LoadApi(ver)
+		if err != nil {
+			return err
+		}
+		for k, _ := range api.Keys {
+			if ac.Base[k] {
+				delete(api.Keys, k)
+			}
+		}
+		ac.Apis = append(ac.Apis, api)
+	}
+	return nil
+}
+
+func (ac *ApiCheck) FincApis(name string) (vers []string) {
+	for _, api := range ac.Apis {
+		if api.Keys[name] {
+			vers = append(vers, api.Ver)
+		}
+	}
+	return
+}
+
+func (ac *ApiCheck) ApiVers() (vers []string) {
+	for _, api := range ac.Apis {
+		vers = append(vers, api.Ver)
+	}
+	return
+}

--- a/app/qexport/main.go
+++ b/app/qexport/main.go
@@ -45,6 +45,10 @@ func init() {
 	flag.StringVar(&flagExportPath, "outpath", "./qlang", "optional set export root path")
 }
 
+var (
+	ac *ApiCheck
+)
+
 func main() {
 	flag.Parse()
 	args := flag.Args()
@@ -57,6 +61,17 @@ func main() {
 	if flagCustomContext != "" {
 		flagDefaultContext = false
 		setCustomContexts(flagCustomContext)
+	}
+
+	//load ApiCheck
+	ac = NewApiCheck()
+	err := ac.LoadBase("go1", "go1.1", "go1.2", "go1.3", "go1.4")
+	if err != nil {
+		log.Println(err)
+	}
+	err = ac.LoadApi("go1.5", "go1.6", "go1.7")
+	if err != nil {
+		log.Println(err)
 	}
 
 	var outpath string
@@ -151,7 +166,22 @@ func export(pkg string, outpath string, skipOSArch bool) error {
 		return
 	}
 
+	checkVer := func(key string) (string, bool) {
+		vers := ac.FincApis(bp.ImportPath + "." + key)
+		if len(vers) > 0 {
+			return vers[0], true
+		}
+		return "", false
+	}
+
+	// go ver map
+	verMap := make(map[string][]string)
+	outfv := func(ver string, k, v string) {
+		verMap[ver] = append(verMap[ver], fmt.Sprintf("Exports[%q]=%s", k, v))
+	}
+
 	var hasTypeExport bool
+	verHasTypeExport := make(map[string]bool)
 
 	//write exports
 	outf(`// Exports is the export table of this module.
@@ -169,7 +199,11 @@ var Exports = map[string]interface{}{
 			if isUint64Const(fn) {
 				fn = "uint64(" + fn + ")"
 			}
-			outf("\t%q:\t%s,\n", name, fn)
+			if vers, ok := checkVer(v); ok {
+				outfv(vers, name, fn)
+			} else {
+				outf("\t%q:\t%s,\n", name, fn)
+			}
 		}
 	}
 
@@ -191,7 +225,10 @@ var Exports = map[string]interface{}{
 			name := v
 			fn := pkgName + "." + v
 			if isStructVar {
-				outf("\t%q:\t&%s,\n", name, fn)
+				fn = "&" + fn
+			}
+			if vers, ok := checkVer(v); ok {
+				outfv(vers, name, fn)
 			} else {
 				outf("\t%q:\t%s,\n", name, fn)
 			}
@@ -204,7 +241,11 @@ var Exports = map[string]interface{}{
 		for _, v := range keys {
 			name := toLowerCaseStyle(v)
 			fn := pkgName + "." + v
-			outf("\t%q:\t%s,\n", name, fn)
+			if vers, ok := checkVer(v); ok {
+				outfv(vers, name, fn)
+			} else {
+				outf("\t%q:\t%s,\n", name, fn)
+			}
 		}
 	}
 
@@ -244,13 +285,21 @@ var Exports = map[string]interface{}{
 					}
 				}
 				fn := pkgName + "." + f
-				outf("\t%q:\t%s,\n", name, fn)
+				if vers, ok := checkVer(f); ok {
+					outfv(vers, name, fn)
+				} else {
+					outf("\t%q:\t%s,\n", name, fn)
+				}
 			}
 
 			for _, f := range funcsOther {
 				name := toLowerCaseStyle(f)
 				fn := pkgName + "." + f
-				outf("\t%q:\t%s,\n", name, fn)
+				if vers, ok := checkVer(f); ok {
+					outfv(vers, name, fn)
+				} else {
+					outf("\t%q:\t%s,\n", name, fn)
+				}
 			}
 		}
 	}
@@ -297,8 +346,15 @@ var Exports = map[string]interface{}{
 
 			//export type, qlang.NewType(reflect.TypeOf((*http.Client)(nil)).Elem())
 			if ast.IsExported(v) {
-				hasTypeExport = true
-				outf("\t%q:\tqlang.NewType(reflect.TypeOf((*%s.%s)(nil)).Elem()),\n", v, pkgName, v)
+				name := v
+				fn := fmt.Sprintf("qlang.NewType(reflect.TypeOf((*%s.%s)(nil)).Elem())", pkgName, v)
+				if vers, ok := checkVer(v); ok {
+					verHasTypeExport[vers] = true
+					outfv(vers, name, fn)
+				} else {
+					hasTypeExport = true
+					outf("\t%q:\t%s,\n", name, fn)
+				}
 			}
 
 			for _, f := range funcsNew {
@@ -312,13 +368,21 @@ var Exports = map[string]interface{}{
 					}
 				}
 				fn := pkgName + "." + f
-				outf("\t%q:\t%s,\n", name, fn)
+				if vers, ok := checkVer(f); ok {
+					outfv(vers, name, fn)
+				} else {
+					outf("\t%q:\t%s,\n", name, fn)
+				}
 			}
 
 			for _, f := range funcsOther {
 				name := toLowerCaseStyle(f)
 				fn := pkgName + "." + f
-				outf("\t%q:\t%s,\n", name, fn)
+				if vers, ok := checkVer(f); ok {
+					outfv(vers, name, fn)
+				} else {
+					outf("\t%q:\t%s,\n", name, fn)
+				}
 			}
 		}
 	}
@@ -335,14 +399,16 @@ var Exports = map[string]interface{}{
 	//write package
 	outHeadf("package %s\n", pkgName)
 
-	//write imports
-	outHeadf("import (\n")
-	outHeadf("\t%q\n", pkg)
-	if hasTypeExport {
-		outHeadf("\t\"reflect\"\n\n")
-		outHeadf("\t\"qlang.io/qlang.spec.v1\"\n")
+	if strings.Count(buf.String(), ",") > 1 {
+		//write imports
+		outHeadf("import (\n")
+		outHeadf("\t%q\n", pkg)
+		if hasTypeExport {
+			outHeadf("\t\"reflect\"\n\n")
+			outHeadf("\t\"qlang.io/qlang.spec.v1\"\n")
+		}
+		outHeadf(")\n\n")
 	}
-	outHeadf(")\n\n")
 
 	// format
 	data, err := format.Source(append(head.Bytes(), buf.Bytes()...))
@@ -363,6 +429,35 @@ var Exports = map[string]interface{}{
 	}
 	defer file.Close()
 	file.Write(data)
+
+	// write version
+	for ver, lines := range verMap {
+		var buf bytes.Buffer
+		buf.WriteString(fmt.Sprintf("// +build %s\n\n", ver))
+		buf.WriteString(fmt.Sprintf("package %s\n\n", pkgName))
+		if verHasTypeExport[ver] {
+			buf.WriteString("import (\n")
+			buf.WriteString(fmt.Sprintf("\t%q\n", bp.ImportPath))
+			buf.WriteString(fmt.Sprintf("\t%q\n\n", "reflect"))
+			buf.WriteString(fmt.Sprintf("\t%q\n", "qlang.io/qlang.spec.v1"))
+			buf.WriteString(")\n")
+		} else {
+			buf.WriteString(fmt.Sprintf("import %q\n", bp.ImportPath))
+		}
+		buf.WriteString("func init() {\n\t")
+		buf.WriteString(strings.Join(lines, "\n\t"))
+		buf.WriteString("\n}")
+		data, err := format.Source(buf.Bytes())
+		if err != nil {
+			return err
+		}
+		file, err := os.Create(filepath.Join(root, pkgName+"-"+strings.Replace(ver, ".", "", 1)+".go"))
+		if err != nil {
+			return err
+		}
+		file.Write(data)
+		file.Close()
+	}
 
 	return nil
 }


### PR DESCRIPTION
通过go/api目录下 go(ver).txt 识别导出api的Go版本，并使用+build version 的方式导出，默认go1-go1.4算为base，而需要+build 导出的为 Go1.5和Go1.6版本。